### PR TITLE
Přidán popis pro endpoint komsend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Některé další programy a nástroje pracující s tímto API najdete na https
 * classificationMarks
 * home
 * komdel
-* komsend
+* [komsend](moduly/komsend.md)
 * nastenka
 * odeslane
 * priloha

--- a/moduly/komsend.md
+++ b/moduly/komsend.md
@@ -1,0 +1,37 @@
+# Modul komsend
+Odeslání zpráv přes školní systém.
+
+Název modulu v URL: `komsend`. Příklad: `https://www.example.com/login.aspx?hx=token&pm=komsend`
+
+## Vstup
+
+Je nutné poslat POST request. V body post requestu je nutné odeslat tyto pole (jako formát form data).
+
+| Key  | Value |
+| ------------- | ------------- |
+| ktext  | Ahoj, toto je testovací zpráva.  |
+| knadpis  |   |
+| kprochar  | U  |
+| kpro | UKBNV |
+| kmno | |
+| kkdy | R |
+| kre | |
+
+Hodnota klíče `kprochar` lze získat z [komenslisty](https://github.com/bakalari-api/bakalari-api/blob/master/moduly/komenslisty.md) (skupina, např. učitel), `kpro` je ze stejného zdroje, jedná se o konkrétní osobu.
+
+Hodnota klíče `kkdy` značí, jestli je vyžadováno potvrzení přečtení. `P` - ano, `R` - ne.
+
+## Výstup
+
+Nepodařilo se získat kladnou odpověď serveru, pokud se vám ji podaří získat, prosím [napište nám přes GitHub](https://github.com/bakalari-api/bakalari-api/issues).
+
+Příklad chybové odpovědi:
+```
+<?xml version="1.0" encoding="utf-8"?>
+<error>
+  <code>105</code>
+  <message>interni chyba: Odeslání e-mailu se nezdařilo.</message>
+</error>
+```
+
+Pozor, tato chybová odpověď nastane i v případě, kdy se zpráva bez problému odešle.

--- a/moduly/komsend.md
+++ b/moduly/komsend.md
@@ -5,7 +5,7 @@ Název modulu v URL: `komsend`. Příklad: `https://www.example.com/login.aspx?h
 
 ## Vstup
 
-Je nutné poslat POST request. V body post requestu je nutné odeslat tyto pole (jako formát form data).
+Je nutné poslat POST request. V body post requestu je nutné odeslat tato pole (jako formát form data).
 
 | Key  | Value |
 | ------------- | ------------- |
@@ -17,13 +17,13 @@ Je nutné poslat POST request. V body post requestu je nutné odeslat tyto pole 
 | kkdy | R |
 | kre | |
 
-Hodnota klíče `kprochar` lze získat z [komenslisty](https://github.com/bakalari-api/bakalari-api/blob/master/moduly/komenslisty.md) (skupina, např. učitel), `kpro` je ze stejného zdroje, jedná se o konkrétní osobu.
+Hodnotu klíče `kprochar` lze získat z [komenslisty](https://github.com/bakalari-api/bakalari-api/blob/master/moduly/komenslisty.md) (skupina, např. učitel), `kpro` je ze stejného zdroje, jedná se o konkrétní osobu.
 
 Hodnota klíče `kkdy` značí, jestli je vyžadováno potvrzení přečtení. `P` - ano, `R` - ne.
 
 ## Výstup
 
-Nepodařilo se získat kladnou odpověď serveru, pokud se vám ji podaří získat, prosím [napište nám přes GitHub](https://github.com/bakalari-api/bakalari-api/issues).
+Nepodařilo se získat kladnou odpověď serveru, pokud se vám ji podaří získat, tak [nám napište na GitHub](https://github.com/bakalari-api/bakalari-api/issues).
 
 Příklad chybové odpovědi:
 ```


### PR DESCRIPTION
Přidán popis endpointu komsend. Server vždy vrací totožné chybové hlášení, a to i když se zpráva v pořádku odešle - bylo by super, kdyby to někdo mohl otestovat u své školy.

Tohle navazuje na #26.